### PR TITLE
Update Danger rules for version code updates

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,11 +1,15 @@
 import {danger, fail, message, schedule, warn} from "danger";
 
+function onlyMetadataUpdates(fileMatch) {
+    return fileMatch.getKeyedPaths().edited.every((x) => x.includes("package.json") || x.includes("yarn.lock"));
+}
+
 if (!danger.github.pr.body.includes("#trivial") && danger.github.pr.body.length < 100) {
     fail("The pull request description must be longer.  Include #trivial to override this.")
 }
 
 const client = danger.git.fileMatch("client/**");
-if (client.edited) {
+if (client.edited && !onlyMetadataUpdates(client)) {
     schedule(danger.git.JSONDiffForFile("client/package.json").then(diff => {
         if (diff) {
             if (!diff.version) {
@@ -20,7 +24,7 @@ if (client.edited) {
 
 
 const server = danger.git.fileMatch("server/**");
-if (server.edited) {
+if (server.edited && !onlyMetadataUpdates(server)) {
     schedule(danger.git.JSONDiffForFile("server/package.json").then(diff => {
         if (diff) {
             if (!diff.version) {
@@ -34,7 +38,7 @@ if (server.edited) {
 }
 
 const root = danger.git.fileMatch("./*");
-if (root.edited) {
+if (root.edited && !onlyMetadataUpdates(root)) {
     schedule(danger.git.JSONDiffForFile("package.json").then(diff => {
         if (diff) {
             if (diff.dependencies || diff.devDependencies) {


### PR DESCRIPTION
Changes
----

- Modified Danger rules such that if the only changes were to package.json or yarn.lock, the version code doesn't have to be updated

Resolved issues
-----

Closes #44