### PR TITLE
Fixed a bug when clicking the link to restart the foot desert wizard

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fd-client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^1.3.5",

--- a/client/src/components/map/wizard/results/ResultsContainer.js
+++ b/client/src/components/map/wizard/results/ResultsContainer.js
@@ -26,12 +26,7 @@ function ResultsContainer(props) {
     }
 
     function beforeFirstStep() {
-        setData(null);
-        setHeader("Your Results");
-        setHeaderColor("black");
-        setHeaderIcon("");
-        props.clearStore();
-        props.firstStep();
+        window.location.reload();
     }
 
     // This is an Effect
@@ -114,7 +109,7 @@ function ResultsContainer(props) {
                         </List.Content>
                     </List.Item>
                     <List.Item>
-                        <List.Icon name={"arrow alternate circle left"}/>
+                        <List.Icon name={"refresh"}/>
                         <List.Content>
                             <List.Header as={"a"} onClick={beforeFirstStep}>Try this food desert wizard
                                 again</List.Header>

--- a/client/src/redux/reducers.js
+++ b/client/src/redux/reducers.js
@@ -9,7 +9,7 @@ export const CLEAR_STORE = "CLEAR_STORE";
 const initialState = {
     address: "",
     location: null,
-    budget: "",
+    budget: [],
     preferredTransit: [],
     preferredTravelTime: [],
     readyToCalculateResults: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "food-deserts",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Changes
----

- Resolved an issue where choices remained selected after clicking the link to restart the food desert wizard that appears when the "you are in a food desert" variant of the results screen is shown.  The solution was to change from trying to reset the Redux store to just reloading the page.  The root cause of the issue is that the Choices component doesn't use the Redux store value for storing the currently selected choices; it merely passes each selection on via a function to a parent component (which then stores that in Redux).  The solution to the root cause is to change the Choices component to be controlled and use the Redux store to store its current selection, but this is non-trivial to implement.